### PR TITLE
Fix link to official documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `deploy` folder contains code to build a [vLLM](https://github.com/vllm-proj
 docker build deploy --build-arg MAX_JOBS=8
 ```
 
-Instructions to run the image can be found in the [official documentation](https://docs.mistral.ai/quickstart).
+Instructions to run the image can be found in the [official documentation](https://docs.mistral.ai/).
 
 ## Installation
 


### PR DESCRIPTION
The README has a line that says:

"Instructions to run the image can be found in the official documentation."

However, https://docs.mistral.ai/quickstart leads to a 404.

On the [home page](https://mistral.ai/) there is a "Quick Start" link that just leads to the root of https://docs.mistral.ai/ so that's what I replaced the link with.

Hope that helps!